### PR TITLE
fix: ignore no-misused-promises rule for arguments and attributes

### DIFF
--- a/src/configs/typescript.js
+++ b/src/configs/typescript.js
@@ -104,5 +104,14 @@ module.exports = {
         },
       },
     ],
+    '@typescript-eslint/no-misused-promises': [
+      'error',
+      {
+        checksVoidReturn: {
+          arguments: false,
+          attributes: false,
+        },
+      },
+    ],
   },
 }


### PR DESCRIPTION
Prevents error when passing `refetch` from `useServiceQuery().query` to components (e.g. `onRefresh` prop on `FlatList`) that expect `() => void` (non-promise void function).