### PR TITLE
fix: bring back comma-dangle generics ignore rule

### DIFF
--- a/src/configs/typescript.ts
+++ b/src/configs/typescript.ts
@@ -17,7 +17,7 @@ module.exports = {
       exports: 'always-multiline',
       functions: 'always-multiline',
       enums: 'always-multiline',
-      generics: 'always-multiline',
+      generics: 'ignore',
       tuples: 'always-multiline',
     }],
     '@typescript-eslint/keyword-spacing': ['error'],


### PR DESCRIPTION
Reverts technology-studio/eslint-config-txo-typescript#291