### PR TITLE
chore: bump workflow pin and pass slack secrets explicitly

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,5 +13,7 @@ permissions:
 jobs:
   semantic-title:
     name: 'Semantic title'
-    uses: technology-studio/github-workflows/.github/workflows/_semantic-title.yml@696ee6d68a8fdb357c5a6e26e748fba32f09a9bb # main
-    secrets: inherit
+    uses: technology-studio/github-workflows/.github/workflows/_semantic-title.yml@761fd17f71ed7420c261c94da183a2fa7fd417ce # main
+    secrets:
+      TXO_SLACK_BOT_APP_TOKEN: ${{ secrets.TXO_SLACK_BOT_APP_TOKEN }}
+      TXO_SLACK_GITHUB_OPS_CHANNEL_ID: ${{ secrets.TXO_SLACK_GITHUB_OPS_CHANNEL_ID }}


### PR DESCRIPTION
Bumps the semantic-title workflow pin and passes the Slack secrets explicitly.