### PR TITLE
fix: remove project parser option from jest config

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -68,9 +68,6 @@ export const jestConfig: TSESLint.FlatConfig.Config = {
       ...globals.jest,
     },
     parser,
-    parserOptions: {
-      project: './__tests__/tsconfig.json',
-    },
   },
   settings: {
     'import/resolver': {


### PR DESCRIPTION
Removes the project parser option from the jest config.